### PR TITLE
[Spot][jsk-spot-teleop] add the jsk-spot-teleop package

### DIFF
--- a/jsk_spot_robot/jsk_spot_teleop/CMakeLists.txt
+++ b/jsk_spot_robot/jsk_spot_teleop/CMakeLists.txt
@@ -1,10 +1,29 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(jsk_spot_teleop)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+    roscpp
+    sensor_msgs
+    std_srvs
+)
 
 catkin_package(
+    LIBRARIES ${PROJECT_NAME}
+    CATKIN_DEPENDS
+        roscpp
+        sensor_msgs
+        std_srvs
 )
 
 include_directories(
+    ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(
+    joystick_teleop
+    src/joystick_teleop.cpp
+)
+target_link_libraries(
+    joystick_teleop
+    ${catkin_LIBRARIES}
 )

--- a/jsk_spot_robot/jsk_spot_teleop/CMakeLists.txt
+++ b/jsk_spot_robot/jsk_spot_teleop/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS
     roscpp
     sensor_msgs
     std_srvs
+    spot_msgs
 )
 
 catkin_package(
@@ -13,6 +14,7 @@ catkin_package(
         roscpp
         sensor_msgs
         std_srvs
+        spot_msgs
 )
 
 include_directories(

--- a/jsk_spot_robot/jsk_spot_teleop/CMakeLists.txt
+++ b/jsk_spot_robot/jsk_spot_teleop/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(jsk_spot_teleop)
+
+find_package(catkin REQUIRED)
+
+catkin_package(
+)
+
+include_directories(
+)

--- a/jsk_spot_robot/jsk_spot_teleop/README.md
+++ b/jsk_spot_robot/jsk_spot_teleop/README.md
@@ -1,0 +1,32 @@
+jsk_spot_teleop
+===============
+
+This package is for teleoperation of Spot with a dualshock 3 controller.
+
+## Prerequities
+
+- Ubuntu 18.04 + ROS Melodic
+- dualshock 3 controller
+
+## How to run
+
+Before using this pacakge, please connect a dualshock 3 controller with a computer
+
+```bash
+roslaunch jsk_spot_teleop teleop.launch
+```
+
+## Key Mapping
+
+|Button   |Function                        |
+|:--------|:-------------------------------|
+|cross    | Stand                          |
+|circle   | Sit                            |
+|rectangle| Self Right                     |
+|start    | Claim                          |
+|select   | release                        |
+|up       | power on                       |
+|down     | power off                      |
+|L1       | Unlock movement                |
+|R2       | Unlock movement with fast mode |
+|R1       |**EStop (gentle)**              |

--- a/jsk_spot_robot/jsk_spot_teleop/README.md
+++ b/jsk_spot_robot/jsk_spot_teleop/README.md
@@ -18,6 +18,8 @@ roslaunch jsk_spot_teleop teleop.launch
 
 ## Key Mapping
 
+![SpotDocumentation](https://user-images.githubusercontent.com/9410362/111890520-68b84400-8a2d-11eb-8f54-dcc6ac7ccbbb.png)
+
 |Button   |Function                        |
 |:--------|:-------------------------------|
 |cross    | Stand                          |

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -20,17 +20,17 @@
           x: 1
           y: 0
         scale_linear:
-          x: 0.4
+          x: 0.5
           y: 0.4
         scale_linear_turbo:
-          x: 0.8
+          x: 1.2
           y: 0.5
         axis_angular:
           yaw: 3
         scale_angular:
           yaw: 0.5
         scale_angular_turbo:
-          yaw: 0.6
+          yaw: 0.7
         enable_button: 4
         enable_turbo_button: 7
     </rosparam>

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -32,7 +32,7 @@
         scale_angular_turbo:
           yaw: 0.6
         enable_button: 4
-        enable_turbo_button: 8
+        enable_turbo_button: 7
     </rosparam>
   </node>
 </launch>

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -48,6 +48,8 @@
       <param name="~button_stand" value="0" />
       <param name="~button_release" value="8" />
       <param name="~button_claim" value="9" />
+
+      <param name="~num_buttons" value="18" />
   </node>
 
   <!--

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -23,7 +23,7 @@
           x: 0.4
           y: 0.4
         scale_linear_turbo:
-          x: 0.5
+          x: 0.8
           y: 0.5
         axis_angular:
           yaw: 3

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -1,7 +1,7 @@
 <launch>
   <arg name="joy_dev" default="/dev/input/js0" />
   <arg name="joy_topic" default="spot_teleop/joy" />
-  <arg name="cmd_vel_topic" default="spot_teleop/cmd_vel" />
+  <arg name="cmd_vel_topic" default="bluetooth_teleop/cmd_vel" />
   
   <node pkg="joy" type="joy_node" name="joy_node">
     <param name="dev" value="$(arg joy_dev)" />

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -35,4 +35,37 @@
         enable_turbo_button: 7
     </rosparam>
   </node>
+
+  <node pkg="jsk_spot_teleop" name="joystick_teleop" type="joystick_teleop">
+      <remap from="joy" to="$(arg joy_topic)" />
+
+      <param name="~button_estop_hard" value="-1" />
+      <param name="~button_estop_gentle" value="5" />
+      <param name="~button_power_off" value="14" />
+      <param name="~button_power_on" value="13" />
+      <param name="~button_self_right" value="3" />
+      <param name="~button_sit" value="1" />
+      <param name="~button_stand" value="0" />
+      <param name="~button_release" value="8" />
+      <param name="~button_claim" value="9" />
+  </node>
+
+  <!--
+    Key Mapping For Teleoperation
+
+    cross : stand
+    circle : sit
+    rectangle : self_right
+    triangle : (None)
+
+    start : claim
+    select : release
+
+    up : power_on
+    down : power_off
+
+    L1 : Unlock movement
+    R1 : Estop (gentle)
+    R2 : Unlock movement with fast mode
+   -->
 </launch>

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -48,6 +48,8 @@
       <param name="~button_stand" value="0" />
       <param name="~button_release" value="8" />
       <param name="~button_claim" value="9" />
+      <param name="~button_stair_mode" value="-1" />
+      <param name="~button_locomotion_mode" value="2" />
 
       <param name="~num_buttons" value="18" />
   </node>
@@ -58,13 +60,13 @@
     cross : stand
     circle : sit
     rectangle : self_right
-    triangle : (None)
+    triangle : toggle locomotion mode
 
     start : claim
     select : release
 
-    up : power_on
     down : power_off
+    up : power_on
 
     L1 : Unlock movement
     R1 : Estop (gentle)

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -36,7 +36,7 @@
     </rosparam>
   </node>
 
-  <node pkg="jsk_spot_teleop" name="joystick_teleop" type="joystick_teleop">
+  <node pkg="jsk_spot_teleop" name="joystick_teleop" type="joystick_teleop" output="screen">
       <remap from="joy" to="$(arg joy_topic)" />
 
       <param name="~button_estop_hard" value="-1" />

--- a/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
+++ b/jsk_spot_robot/jsk_spot_teleop/launch/teleop.launch
@@ -1,0 +1,38 @@
+<launch>
+  <arg name="joy_dev" default="/dev/input/js0" />
+  <arg name="joy_topic" default="spot_teleop/joy" />
+  <arg name="cmd_vel_topic" default="spot_teleop/cmd_vel" />
+  
+  <node pkg="joy" type="joy_node" name="joy_node">
+    <param name="dev" value="$(arg joy_dev)" />
+    <param name="deadzone" value="0.3" />
+    <param name="autorepeat_rate" value="20" />
+
+    <remap from="joy" to="$(arg joy_topic)" />
+  </node>
+
+  <node pkg="teleop_twist_joy" name="teleop_twist_joy" type="teleop_node">
+    <remap from="joy" to="$(arg joy_topic)" />
+    <remap from="cmd_vel" to="$(arg cmd_vel_topic)" />
+
+    <rosparam subst_value="True">
+        axis_linear:
+          x: 1
+          y: 0
+        scale_linear:
+          x: 0.4
+          y: 0.4
+        scale_linear_turbo:
+          x: 0.5
+          y: 0.5
+        axis_angular:
+          yaw: 3
+        scale_angular:
+          yaw: 0.5
+        scale_angular_turbo:
+          yaw: 0.6
+        enable_button: 4
+        enable_turbo_button: 8
+    </rosparam>
+  </node>
+</launch>

--- a/jsk_spot_robot/jsk_spot_teleop/package.xml
+++ b/jsk_spot_robot/jsk_spot_teleop/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>jsk_spot_teleop</name>
+  <version>1.1.0</version>
+  <description>The jsk_spot_teleop package</description>
+
+  <maintainer email="k-okada@jsk.t.u-tokyo.ac.jp">Kei Okada</maintainer>
+  <maintainer email="shinjo@jsk.imi.i.u-tokyo.ac.jp">Koki Shinjo</maintainer>
+
+  <author email="shinjo@jsk.imi.i.u-tokyo.ac.jp">Koki Shinjo</author>
+
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <exec_depend>joy</exec_depend>
+  <exec_depend>teleop_twist_joy</exec_depend>
+
+  <export>
+  </export>
+</package>

--- a/jsk_spot_robot/jsk_spot_teleop/package.xml
+++ b/jsk_spot_robot/jsk_spot_teleop/package.xml
@@ -16,12 +16,14 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>spot_msgs</build_depend>
 
   <exec_depend>roscpp</exec_depend>
   <exec_depend>joy</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
+  <exec_depend>spot_msgs</exec_depend>
 
 
   <export>

--- a/jsk_spot_robot/jsk_spot_teleop/package.xml
+++ b/jsk_spot_robot/jsk_spot_teleop/package.xml
@@ -12,8 +12,17 @@
   <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
+
+  <exec_depend>roscpp</exec_depend>
   <exec_depend>joy</exec_depend>
   <exec_depend>teleop_twist_joy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
+
 
   <export>
   </export>

--- a/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
+++ b/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
@@ -303,12 +303,16 @@ public:
                 and button_locomotion_mode_ < num_buttons_ ) {
             if ( msg->buttons[button_locomotion_mode_] == 1 ) {
                 if ( not pressed_[button_locomotion_mode_] ) {
-                    std_srvs::SetBool::Response res;
+                    spot_msgs::SetLocomotion::Response res;
                     if ( client_locomotion_mode_.call(req_next_locomotion_mode_,res) && res.success ) {
                         ROS_INFO_STREAM("Service 'locomotion_mode' succeeded. set to " << req_next_locomotion_mode_.locomotion_mode);
                         switch (req_next_locomotion_mode_.locomotion_mode) {
                             case 1:
                                 req_next_locomotion_mode_.locomotion_mode = 4;
+                                break;
+                            case 4:
+                                req_next_locomotion_mode_.locomotion_mode = 1;
+                                break;
                             default:
                                 req_next_locomotion_mode_.locomotion_mode = 1;
                         }

--- a/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
+++ b/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
@@ -15,8 +15,16 @@ public:
         ros::param::param<int>("~button_self_right", button_self_right_, -1);
         ros::param::param<int>("~button_sit", button_sit_, -1);
         ros::param::param<int>("~button_stand", button_stand_, -1);
+        ros::param::param<int>("~button_stop", button_stop_, -1);
         ros::param::param<int>("~button_release", button_release_, -1);
         ros::param::param<int>("~button_claim", button_claim_, -1);
+
+        ros::param::param<int>("~num_buttons", num_buttons_, 0);
+        num_buttons_ = num_buttons_ < 0 ? 0 : num_buttons_;
+        pressed_.resize(num_buttons_);
+        for ( auto index: pressed_ ) {
+            index = false;
+        }
 
         client_estop_hard_ = nh.serviceClient<std_srvs::Trigger>("/spot/estop/hard");
         client_estop_gentle_ = nh.serviceClient<std_srvs::Trigger>("/spot/estop/gentle");
@@ -25,6 +33,7 @@ public:
         client_self_right_ = nh.serviceClient<std_srvs::Trigger>("/spot/self_right");
         client_sit_ = nh.serviceClient<std_srvs::Trigger>("/spot/sit");
         client_stand_ = nh.serviceClient<std_srvs::Trigger>("/spot/stand");
+        client_stop_ = nh.serviceClient<std_srvs::Trigger>("/spot/stop");
         client_release_ = nh.serviceClient<std_srvs::Trigger>("/spot/release");
         client_claim_ = nh.serviceClient<std_srvs::Trigger>("/spot/claim");
 
@@ -36,126 +45,220 @@ public:
         std_srvs::Trigger srv;
 
         // estop_hard
-        if ( ( button_estop_hard_ >= 0 and button_estop_hard_ < msg->buttons.size() ) ) {
+        if ( button_estop_hard_ >= 0
+                and button_estop_hard_ < msg->buttons.size()
+                and button_estop_hard_ < num_buttons_ ) {
             if ( msg->buttons[button_estop_hard_] == 1 ) {
-                if ( client_estop_hard_.call(srv) && srv.response.success ) {
-                    ROS_INFO("Service 'estop_hard' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'estop_hard' failed.");
+                if ( not pressed_[button_estop_hard_] ) {
+                    if ( client_estop_hard_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'estop_hard' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'estop_hard' failed.");
+                    }
+                    pressed_[button_estop_hard_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_estop_hard_] ) {
+                    pressed_[button_estop_hard_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'estop_hard' is disabled.");
         }
 
         // estop_gentle
-        if ( ( button_estop_gentle_ >= 0 and button_estop_gentle_ < msg->buttons.size() ) ) {
+        if ( button_estop_gentle_ >= 0
+                and button_estop_gentle_ < msg->buttons.size()
+                and button_estop_gentle_ < num_buttons_ ) {
             if ( msg->buttons[button_estop_gentle_] == 1 ) {
-                if ( client_estop_gentle_.call(srv) && srv.response.success ) {
-                    ROS_INFO("Service 'estop_gentle' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'estop_gentle' failed.");
+                if ( not pressed_[button_estop_gentle_] ) {
+                    if ( client_estop_gentle_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'estop_gentle' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'estop_gentle' failed.");
+                    }
+                    pressed_[button_estop_gentle_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_estop_gentle_] ) {
+                    pressed_[button_estop_gentle_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'estop_gentle' is disabled.");
         }
 
         // power_off
-        if ( ( button_power_off_ >= 0 and button_power_off_ < msg->buttons.size() ) ) {
+        if ( button_power_off_ >= 0
+                and button_power_off_ < msg->buttons.size()
+                and button_power_off_ < num_buttons_ ) {
             if ( msg->buttons[button_power_off_] == 1 ) {
-                if ( client_power_off_.call(srv) && srv.response.success ) {
-                    ROS_INFO("Service 'power_off' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'power_off' failed.");
+                if ( not pressed_[button_power_off_] ) {
+                    if ( client_power_off_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'power_off' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'power_off' failed.");
+                    }
+                    pressed_[button_power_off_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_power_off_] ) {
+                    pressed_[button_power_off_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'power_off' is disabled.");
         }
 
         // power_on
-        if ( ( button_power_on_ >= 0 and button_power_on_ < msg->buttons.size() ) ) {
+        if ( button_power_on_ >= 0
+                and button_power_on_ < msg->buttons.size()
+                and button_power_on_ < num_buttons_ ) {
             if ( msg->buttons[button_power_on_] == 1 ) {
-                if ( client_power_on_.call(srv) && srv.response.success ) {
-                    ROS_INFO("Service 'power_on' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'power_on' failed.");
+                if ( not pressed_[button_power_on_] ) {
+                    if ( client_power_on_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'power_on' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'power_on' failed.");
+                    }
+                    pressed_[button_power_on_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_power_on_] ) {
+                    pressed_[button_power_on_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'power_on' is disabled.");
         }
 
         // self_right
-        if ( ( button_self_right_ >= 0 and button_self_right_ < msg->buttons.size() ) ) {
+        if ( button_self_right_ >= 0
+                and button_self_right_ < msg->buttons.size()
+                and button_self_right_ < num_buttons_ ) {
             if ( msg->buttons[button_self_right_] == 1 ) {
-                if ( client_self_right_.call(srv) && srv.response.success ) {
-                    ROS_INFO("Service 'self_right' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'self_right' failed.");
+                if ( not pressed_[button_self_right_] ) {
+                    if ( client_self_right_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'self_right' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'self_right' failed.");
+                    }
+                    pressed_[button_self_right_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_self_right_] ) {
+                    pressed_[button_self_right_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'self_right' is disabled.");
         }
 
         // sit
-        if ( ( button_sit_ >= 0 and button_sit_ < msg->buttons.size() ) ) {
+        if ( button_sit_ >= 0
+                and button_sit_ < msg->buttons.size()
+                and button_sit_ < num_buttons_ ) {
             if ( msg->buttons[button_sit_] == 1 ) {
-                if ( client_sit_.call(srv) && srv.response.success ) {
-                    ROS_INFO("Service 'sit' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'sit' failed.");
+                if ( not pressed_[button_sit_] ) {
+                    if ( client_sit_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'sit' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'sit' failed.");
+                    }
+                    pressed_[button_sit_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_sit_] ) {
+                    pressed_[button_sit_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'sit' is disabled.");
         }
 
         // stand
-        if ( ( button_stand_ >= 0 and button_stand_ < msg->buttons.size() ) ) {
+        if ( button_stand_ >= 0
+                and button_stand_ < msg->buttons.size()
+                and button_stand_ < num_buttons_ ) {
             if ( msg->buttons[button_stand_] == 1 ) {
-                if ( client_stand_.call(srv) && srv.response.success ) {
-                    ROS_INFO("Service 'stand' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'stand' failed.");
+                if ( not pressed_[button_stand_] ) {
+                    if ( client_stand_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'stand' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'stand' failed.");
+                    }
+                    pressed_[button_stand_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_stand_] ) {
+                    pressed_[button_stand_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'stand' is disabled.");
         }
 
-        // release
-        if ( ( button_release_ >= 0 and button_release_ < msg->buttons.size() ) ) {
-            if ( msg->buttons[button_release_] == 1 ) {
-                if ( client_release_.call(srv) && srv.response.success ) {
-                    ROS_INFO("Service 'release' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'release' failed.");
+        // stop
+        if ( button_stop_ >= 0
+                and button_stop_ < msg->buttons.size()
+                and button_stop_ < num_buttons_ ) {
+            if ( msg->buttons[button_stop_] == 1 ) {
+                if ( not pressed_[button_stop_] ) {
+                    if ( client_stop_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'stop' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'stop' failed.");
+                    }
+                    pressed_[button_stop_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_stop_] ) {
+                    pressed_[button_stop_] = false;
+                }
+            }
+        } else {
+            ROS_DEBUG("Button 'stop' is disabled.");
+        }
+
+        // release
+        if ( button_release_ >= 0
+                and button_release_ < msg->buttons.size()
+                and button_release_ < num_buttons_ ) {
+            if ( msg->buttons[button_release_] == 1 ) {
+                if ( not pressed_[button_release_] ) {
+                    if ( client_release_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'release' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'release' failed.");
+                    }
+                    pressed_[button_release_] = true;
+                }
+            } else {
+                if ( pressed_[button_release_] ) {
+                    pressed_[button_release_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'release' is disabled.");
         }
 
         // claim
-        if ( ( button_claim_ >= 0 and button_claim_ < msg->buttons.size() ) ) {
+        if ( button_claim_ >= 0
+                and button_claim_ < msg->buttons.size()
+                and button_claim_ < num_buttons_ ) {
             if ( msg->buttons[button_claim_] == 1 ) {
-                if ( client_claim_.call(srv) ) {
-                    ROS_INFO("Service 'claim' succeeded.");
-                } else {
-                    ROS_ERROR("Service 'claim' failed.");
+                if ( not pressed_[button_claim_] ) {
+                    if ( client_claim_.call(srv) && srv.response.success ) {
+                        ROS_INFO("Service 'claim' succeeded.");
+                    } else {
+                        ROS_ERROR("Service 'claim' failed.");
+                    }
+                    pressed_[button_claim_] = true;
                 }
-                return;
+            } else {
+                if ( pressed_[button_claim_] ) {
+                    pressed_[button_claim_] = false;
+                }
             }
         } else {
             ROS_DEBUG("Button 'claim' is disabled.");
@@ -163,27 +266,32 @@ public:
     }
 
 private:
+    int button_estop_hard_;
+    int button_estop_gentle_;
+    int button_power_off_;
+    int button_power_on_;
+    int button_self_right_;
     int button_sit_;
     int button_stand_;
-    int button_self_right_;
-    int button_claim_;
+    int button_stop_;
     int button_release_;
-    int button_power_on_;
-    int button_power_off_;
-    int button_estop_gentle_;
-    int button_estop_hard_;
+    int button_claim_;
 
+    ros::ServiceClient client_estop_hard_;
+    ros::ServiceClient client_estop_gentle_;
+    ros::ServiceClient client_power_off_;
+    ros::ServiceClient client_power_on_;
+    ros::ServiceClient client_self_right_;
     ros::ServiceClient client_sit_;
     ros::ServiceClient client_stand_;
-    ros::ServiceClient client_self_right_;
-    ros::ServiceClient client_claim_;
+    ros::ServiceClient client_stop_;
     ros::ServiceClient client_release_;
-    ros::ServiceClient client_power_on_;
-    ros::ServiceClient client_power_off_;
-    ros::ServiceClient client_estop_gentle_;
-    ros::ServiceClient client_estop_hard_;
+    ros::ServiceClient client_claim_;
 
     ros::Subscriber sub_joy_;
+
+    int num_buttons_;
+    std::vector<bool> pressed_;
 };
 
 

--- a/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
+++ b/jsk_spot_robot/jsk_spot_teleop/src/joystick_teleop.cpp
@@ -1,0 +1,199 @@
+#include <ros/ros.h>
+
+#include <sensor_msgs/Joy.h>
+#include <std_srvs/Trigger.h>
+
+class TeleopManager
+{
+public:
+    void init(ros::NodeHandle& nh)
+    {
+        ros::param::param<int>("~button_estop_hard", button_estop_hard_, -1);
+        ros::param::param<int>("~button_estop_gentle", button_estop_gentle_, -1);
+        ros::param::param<int>("~button_power_off", button_power_off_, -1);
+        ros::param::param<int>("~button_power_on", button_power_on_, -1);
+        ros::param::param<int>("~button_self_right", button_self_right_, -1);
+        ros::param::param<int>("~button_sit", button_sit_, -1);
+        ros::param::param<int>("~button_stand", button_stand_, -1);
+        ros::param::param<int>("~button_release", button_release_, -1);
+        ros::param::param<int>("~button_claim", button_claim_, -1);
+
+        client_estop_hard_ = nh.serviceClient<std_srvs::Trigger>("/spot/estop/hard");
+        client_estop_gentle_ = nh.serviceClient<std_srvs::Trigger>("/spot/estop/gentle");
+        client_power_off_ = nh.serviceClient<std_srvs::Trigger>("/spot/power_off");
+        client_power_on_ = nh.serviceClient<std_srvs::Trigger>("/spot/power_on");
+        client_self_right_ = nh.serviceClient<std_srvs::Trigger>("/spot/self_right");
+        client_sit_ = nh.serviceClient<std_srvs::Trigger>("/spot/sit");
+        client_stand_ = nh.serviceClient<std_srvs::Trigger>("/spot/stand");
+        client_release_ = nh.serviceClient<std_srvs::Trigger>("/spot/release");
+        client_claim_ = nh.serviceClient<std_srvs::Trigger>("/spot/claim");
+
+        sub_joy_ = nh.subscribe<sensor_msgs::Joy, TeleopManager>("joy", 1, &TeleopManager::callbackJoy, this);
+    }
+
+    void callbackJoy(const sensor_msgs::Joy::ConstPtr& msg)
+    {
+        std_srvs::Trigger srv;
+
+        // estop_hard
+        if ( ( button_estop_hard_ >= 0 and button_estop_hard_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_estop_hard_] == 1 ) {
+                if ( client_estop_hard_.call(srv) && srv.response.success ) {
+                    ROS_INFO("Service 'estop_hard' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'estop_hard' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'estop_hard' is disabled.");
+        }
+
+        // estop_gentle
+        if ( ( button_estop_gentle_ >= 0 and button_estop_gentle_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_estop_gentle_] == 1 ) {
+                if ( client_estop_gentle_.call(srv) && srv.response.success ) {
+                    ROS_INFO("Service 'estop_gentle' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'estop_gentle' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'estop_gentle' is disabled.");
+        }
+
+        // power_off
+        if ( ( button_power_off_ >= 0 and button_power_off_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_power_off_] == 1 ) {
+                if ( client_power_off_.call(srv) && srv.response.success ) {
+                    ROS_INFO("Service 'power_off' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'power_off' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'power_off' is disabled.");
+        }
+
+        // power_on
+        if ( ( button_power_on_ >= 0 and button_power_on_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_power_on_] == 1 ) {
+                if ( client_power_on_.call(srv) && srv.response.success ) {
+                    ROS_INFO("Service 'power_on' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'power_on' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'power_on' is disabled.");
+        }
+
+        // self_right
+        if ( ( button_self_right_ >= 0 and button_self_right_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_self_right_] == 1 ) {
+                if ( client_self_right_.call(srv) && srv.response.success ) {
+                    ROS_INFO("Service 'self_right' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'self_right' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'self_right' is disabled.");
+        }
+
+        // sit
+        if ( ( button_sit_ >= 0 and button_sit_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_sit_] == 1 ) {
+                if ( client_sit_.call(srv) && srv.response.success ) {
+                    ROS_INFO("Service 'sit' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'sit' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'sit' is disabled.");
+        }
+
+        // stand
+        if ( ( button_stand_ >= 0 and button_stand_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_stand_] == 1 ) {
+                if ( client_stand_.call(srv) && srv.response.success ) {
+                    ROS_INFO("Service 'stand' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'stand' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'stand' is disabled.");
+        }
+
+        // release
+        if ( ( button_release_ >= 0 and button_release_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_release_] == 1 ) {
+                if ( client_release_.call(srv) && srv.response.success ) {
+                    ROS_INFO("Service 'release' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'release' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'release' is disabled.");
+        }
+
+        // claim
+        if ( ( button_claim_ >= 0 and button_claim_ < msg->buttons.size() ) ) {
+            if ( msg->buttons[button_claim_] == 1 ) {
+                if ( client_claim_.call(srv) ) {
+                    ROS_INFO("Service 'claim' succeeded.");
+                } else {
+                    ROS_ERROR("Service 'claim' failed.");
+                }
+                return;
+            }
+        } else {
+            ROS_DEBUG("Button 'claim' is disabled.");
+        }
+    }
+
+private:
+    int button_sit_;
+    int button_stand_;
+    int button_self_right_;
+    int button_claim_;
+    int button_release_;
+    int button_power_on_;
+    int button_power_off_;
+    int button_estop_gentle_;
+    int button_estop_hard_;
+
+    ros::ServiceClient client_sit_;
+    ros::ServiceClient client_stand_;
+    ros::ServiceClient client_self_right_;
+    ros::ServiceClient client_claim_;
+    ros::ServiceClient client_release_;
+    ros::ServiceClient client_power_on_;
+    ros::ServiceClient client_power_off_;
+    ros::ServiceClient client_estop_gentle_;
+    ros::ServiceClient client_estop_hard_;
+
+    ros::Subscriber sub_joy_;
+};
+
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "spot_teleop");
+    ros::NodeHandle nh;
+
+    TeleopManager teleop;
+    teleop.init(nh);
+
+    ros::spin();
+}


### PR DESCRIPTION
Added `jsk-spot-teleop` package.
This package includes
- `joystick_teleop` node to call spot_ros's ros services and send cmd_vel from a gamepad
- `teleop.launch` to launch ros nodes to control spot from a gamepad, which include `joy_node` from `joy` package, `teleop_node` from `twist_teleop_joy` package and `joystick_teleop` node from this package.

By default, button map of teleop.launch is like

|Button   |Function                        |
|:--------|:-------------------------------|
|cross    | Stand                          |
|circle   | Sit                            |
|rectangle| Self Right                     |
|start    | Claim                          |
|select   | release                        |
|up       | power on                       |
|down     | power off                      |
|L1       | Unlock movement                |
|R2       | Unlock movement with fast mode |
|R1       |**EStop (gentle)**              |