### PR TITLE
[unitreeeus] Return coords in (send *go1* :body-pose)

### DIFF
--- a/jsk_unitree_robot/unitreeeus/go1-utils.l
+++ b/jsk_unitree_robot/unitreeeus/go1-utils.l
@@ -52,22 +52,23 @@
                 ))
   ;;
   (:body-pose
-   (pose &rest args)
-   (let (target-coords)
-     (setq target-coords (send self :copy-worldcoords))
-     (if (or (vectorp pose) (listp pose))
-         (progn
-           (ros::ros-debug "Got r p y float-vector or list as args.")
-           (setq pose (instance coordinates :init :rpy (list (elt pose 2) (elt pose 1) (elt pose 0)))))
-       (ros::ros-debug "Got coords variable as args."))
-     (send target-coords :transform pose)
-     (send* self :fullbody-inverse-kinematics
-            target-coords (send self :base_lk)
-            :rotation-axis t
-            :translation-axis t
-            :debug-view nil
-            args)
-     ))
+   (&optional pose &rest args)
+   (when pose
+     (let (target-coords)
+       (setq target-coords (send self :copy-worldcoords))
+       (if (or (vectorp pose) (listp pose))
+           (progn
+             (ros::ros-debug "Got r p y float-vector or list as args.")
+             (setq pose (instance coordinates :init :rpy (list (elt pose 2) (elt pose 1) (elt pose 0)))))
+           (ros::ros-debug "Got coords variable as args."))
+       (send target-coords :transform pose)
+       (send* self :fullbody-inverse-kinematics
+              target-coords (send self :base_lk)
+              :rotation-axis t
+              :translation-axis t
+              :debug-view nil
+              args)))
+     (send self :coords))
   ;;
   (:look-at
    (pos &rest args)


### PR DESCRIPTION
In this PR, `(send *go1* :body-pose)` return coords instead of angle-vector .

We can execute following command with this PR .
We can operate the real robot with an interface similar to `(send *ri* :angle-vector (send *robot* :angle-vector))`
```lisp
(send *ri* :body-pose (send *go1* :body-pose #f(0.1 0 0)))
;;
(send *go1* :body-pose #f(0 0 0.1))
(send *ri* :body-pose (send *go1* :body-pose))
```