### PR TITLE
[jsk_unitree_startup] Fix body pose to enable up-and-down motion

### DIFF
--- a/jsk_unitree_robot/jsk_unitree_startup/scripts/unitree_service.py
+++ b/jsk_unitree_robot/jsk_unitree_startup/scripts/unitree_service.py
@@ -101,6 +101,7 @@ class UnitreeService(object):
         q = pose.orientation
         msg = HighCmd()
         msg.mode = 1
+        msg.bodyHeight = pose.position.z
         msg.euler = tf.transformations.euler_from_quaternion([q.x, q.y, q.z, q.w])  # RPY
         self.highlevel_pub.publish(msg)
         return


### PR DESCRIPTION
This PR adds body.Height parameter to body-pose to enable  up-and-down motion.

UP
```(send *ri* :body-pose (coords :pos #f(0 0 30))```
DOWN
```(send *ri* :body-pose (coords :pos #f(0 0 -150))```