### PR TITLE
[jsk_unitree_startup] Add network config for USB LTE module

### DIFF
--- a/jsk_unitree_robot/cross/install.sh
+++ b/jsk_unitree_robot/cross/install.sh
@@ -112,6 +112,7 @@ function copy_data () {
     # enable Internet with USB LTE module
     if [[ "${hostname}" == "192.168.123.161" ]]; then
         sshpass -p $PASS ssh -t ${user}@${hostname} "source /opt/jsk/User/user_setup.bash; sudo cp -f \$(rospack find jsk_unitree_startup)/config/dhcpcd.conf /etc/dhcpcd.conf"
+        sshpass -p $PASS ssh -t ${user}@${hostname} "sudo systemctl restart dhcpcd"
     fi
     set +x
 }

--- a/jsk_unitree_robot/cross/install.sh
+++ b/jsk_unitree_robot/cross/install.sh
@@ -34,13 +34,13 @@ set -euf -o pipefail
 # Check if ros has been cross-compilled
 if [ ! -d "$(pwd)/${TARGET_MACHINE}_${TARGET_DIRECTORY}" ]; then
     echo "ERROR: System directory is not found" 1>&2
-    echo "ERROR: please build ros for pepper first" 1>&2
+    echo "ERROR: please build ros for Unitree first" 1>&2
     exit 1
 fi
 
 # Get password
 
-# Receive pepper hostname or ip
+# Receive Unitree hostname or ip
 echo 'Automatic install script for ros unitree Go1 \n'
 echo "!!! CAUTION !!! If you modifeid files in the Go1, it will be removed/overwrited"
 

--- a/jsk_unitree_robot/cross/install.sh
+++ b/jsk_unitree_robot/cross/install.sh
@@ -108,6 +108,11 @@ function copy_data () {
         #
         sshpass -p $PASS ssh -t ${user}@${hostname} "ls -al /etc/udev/rules.d/; sudo systemctl restart udev"
     fi
+
+    # enable Internet with USB LTE module
+    if [[ "${hostname}" == "192.168.123.161" ]]; then
+        sshpass -p $PASS ssh -t ${user}@${hostname} "source /opt/jsk/User/user_setup.bash; sudo cp -f \$(rospack find jsk_unitree_startup)/config/dhcpcd.conf /etc/dhcpcd.conf"
+    fi
     set +x
 }
 

--- a/jsk_unitree_robot/jsk_unitree_startup/config/dhcpcd.conf
+++ b/jsk_unitree_robot/jsk_unitree_startup/config/dhcpcd.conf
@@ -1,0 +1,79 @@
+# A sample configuration for dhcpcd.
+# See dhcpcd.conf(5) for details.
+
+# Allow users of this group to interact with dhcpcd via the control socket.
+#controlgroup wheel
+
+# Inform the DHCP server of our hostname for DDNS.
+hostname
+
+# Use the hardware address of the interface for the Client ID.
+clientid
+# or
+# Use the same DUID + IAID as set in DHCPv6 for DHCPv4 ClientID as per RFC4361.
+# Some non-RFC compliant DHCP servers do not reply with this set.
+# In this case, comment out duid and enable clientid above.
+#duid
+
+# Persist interface configuration when dhcpcd exits.
+persistent
+
+# Rapid commit support.
+# Safe to enable by default because it requires the equivalent option set
+# on the server to actually work.
+option rapid_commit
+
+# A list of options to request from the DHCP server.
+option domain_name_servers, domain_name, domain_search, host_name
+option classless_static_routes
+# Respect the network MTU. This is applied to DHCP routes.
+option interface_mtu
+
+# Most distributions have NTP support.
+#option ntp_servers
+
+# A ServerID is required by RFC2131.
+require dhcp_server_identifier
+
+# Generate SLAAC address using the Hardware Address of the interface
+#slaac hwaddr
+# OR generate Stable Private IPv6 Addresses based from the DUID
+slaac private
+
+# Example static IP configuration:
+#interface eth0
+#static ip_address=192.168.0.10/24
+#static ip6_address=fd51:42f8:caae:d92e::ff/64
+#static routers=192.168.0.1
+#static domain_name_servers=192.168.0.1 8.8.8.8 fd51:42f8:caae:d92e::1
+
+# It is possible to fall back to a static IP if DHCP fails:
+# define static profile
+#profile static_eth0
+#static ip_address=192.168.1.23/24
+#static routers=192.168.1.1
+#static domain_name_servers=192.168.1.1
+
+# fallback to static profile on eth0
+#interface eth0
+#fallback static_eth0
+
+interface eth0
+static ip_address=192.168.123.161/24
+static routers=192.168.123.1
+static domain_name_servers=192.168.123.1
+
+interface wlan1
+static ip_address=192.168.12.1/24
+static routers=192.168.12.1
+nohook wpa_supplicant
+
+################################################
+# For USB LTE module
+# This enables Unitree to connect the Internet.
+# Down metric to choose usb0 on a priority basis
+################################################
+interface usb0
+metric 100
+static domain_name_servers=8.8.8.8
+###############################################


### PR DESCRIPTION
I add Unitree network config to use LTE module and install it automatically.