### PR TITLE
Add mux for lead teleop using app_manager

### DIFF
--- a/jsk_unitree_robot/cross/repos/unitree.repos
+++ b/jsk_unitree_robot/cross/repos/unitree.repos
@@ -17,3 +17,7 @@ repositories:
     # we do not include https://github.com/unitreerobotics/unitree_ros_to_real/pull/27 in
     #   k-okada/unitree_ros_to_real:develop
     version: develop
+  app_manager:
+    type: git
+    url: https://github.com/Affonso-Gui/app_manager
+    version: enable-parallel-run-apps

--- a/jsk_unitree_robot/jsk_unitree_startup/apps/lead_teleop/lead_teleop.xml
+++ b/jsk_unitree_robot/jsk_unitree_startup/apps/lead_teleop/lead_teleop.xml
@@ -1,5 +1,6 @@
 <launch>
   <include file="$(find jsk_unitree_startup)/launch/lead_teleop.launch" >
     <arg name="launch_serial_node" value="false" />
+    <arg name="joy_topic" value="/joy_head/joy_raw_to_input" />
   </include>
 </launch>

--- a/jsk_unitree_robot/jsk_unitree_startup/launch/lead_teleop.launch
+++ b/jsk_unitree_robot/jsk_unitree_startup/launch/lead_teleop.launch
@@ -2,19 +2,23 @@
   <arg name="launch_serial_node" default="true" />
   <!-- copied from https://github.com/jsk-ros-pkg/jsk_robot/blob/9282d6b2903223d3880507be34aa646e1e048506/jsk_spot_robot/jsk_spot_head_joy/launch/head_teleop.launch -->
   <!-- PXN-2113 Pro 11ff:0837 -->
-  <arg name="joy_dev" default="/dev/input/js0" />
+  <arg name="joy_dev" default="/dev/ttyACM0" />
+  <arg name="joy_topic" default="/joy_head/joy_raw" />
   <arg name="cmd_vel_topic" default="/go1/cmd_vel" />
   <arg name="pass_through" default="false" />
   <arg name="deadzone" default="0.3" />
+  <arg name="debounce_period" default="50" />
+  <arg name="press_interval" default="500" />
 
   <!-- custom hardware for rosserial/joy node -->
   <group if="$(arg launch_serial_node)" >
-    <node name="serial_node" type="serial_node.py"
-          pkg="rosserial_python" >
-      <remap from="joy" to="/joy_head/joy_raw" />
-      <param name="port" value="/dev/ttyACM0" />
-      <param name="deadzone" value="$(arg deadzone)" />
-    </node>
+    <include file="$(find jsk_unitree_startup)/launch/rosserial_node.launch" >
+      <arg name="joy" value="$(arg joy_topic)" />
+      <arg name="port" value="$(arg joy_dev)" />
+      <arg name="deadzone" value="$(arg deadzone)" />
+      <arg name="debounce_period" value="$(arg debounce_period)" />
+      <arg name="press_interval" value="$(arg press_interval)" />
+    </include>
   </group>
 
   <include file="$(find jsk_robot_startup)/launch/head_teleop.launch">

--- a/jsk_unitree_robot/jsk_unitree_startup/launch/lead_teleop.launch
+++ b/jsk_unitree_robot/jsk_unitree_startup/launch/lead_teleop.launch
@@ -22,6 +22,7 @@
   </group>
 
   <include file="$(find jsk_robot_startup)/launch/head_teleop.launch">
+    <arg name="joy_topic_raw" default="$(arg joy_topic)" />
     <arg name="joy_name_space" default="/go1/" />
     <arg name="launch_joy_node" default="false" />
     <arg name="teleop_twist_joy_param_file" default="$(find jsk_unitree_startup)/config/lead_teleop_twist_joy.yaml" />

--- a/jsk_unitree_robot/jsk_unitree_startup/launch/rosserial_node.launch
+++ b/jsk_unitree_robot/jsk_unitree_startup/launch/rosserial_node.launch
@@ -5,13 +5,19 @@
        But app_manager start in nano2 (192.168.123.14) and
        lead_teleop.launch start in nano2 machine. -->
   <!-- PXN-2113 Pro 11ff:0837 -->
+  <arg name="joy_topic" default="/joy_head/joy_raw" />
+  <arg name="joy_dev" default="/dev/ttyACM0" />
   <arg name="deadzone" default="0.3" />
+  <arg name="debounce_period" default="50" />
+  <arg name="press_interval" default="500" />
 
   <!-- custom hardware for rosserial/joy node -->
   <node name="serial_node" type="serial_node.py"
         pkg="rosserial_python" respawn="true" >
-    <remap from="joy" to="/joy_head/joy_raw" />
-    <param name="port" value="/dev/ttyACM0" />
+    <remap from="joy" to="$(arg joy_topic)" />
+    <param name="port" value="$(arg joy_dev)" />
     <param name="deadzone" value="$(arg deadzone)" />
+    <param name="debounce_period" value="$(arg debounce_period)" />
+    <param name="press_interval" value="$(arg press_interval)" />
   </node>
 </launch>

--- a/jsk_unitree_robot/jsk_unitree_startup/launch/rosserial_node.launch
+++ b/jsk_unitree_robot/jsk_unitree_startup/launch/rosserial_node.launch
@@ -5,7 +5,9 @@
        But app_manager start in nano2 (192.168.123.14) and
        lead_teleop.launch start in nano2 machine. -->
   <!-- PXN-2113 Pro 11ff:0837 -->
-  <arg name="joy_topic" default="/joy_head/joy_raw" />
+  <arg name="joy_topic" default="/joy_head/joy_raw" doc="joy topic read by rosserial" />
+  <arg name="joy_topic_dummy" default="/joy_head/joy_dummy" doc="Dummy input (no signal)." />
+  <arg name="joy_topic_to_input" default="/joy_head/joy_raw_to_input" doc="joy topic that is switched and output by mux." />
   <arg name="joy_dev" default="/dev/ttyACM0" />
   <arg name="deadzone" default="0.3" />
   <arg name="debounce_period" default="50" />
@@ -20,4 +22,21 @@
     <param name="debounce_period" value="$(arg debounce_period)" />
     <param name="press_interval" value="$(arg press_interval)" />
   </node>
+
+  <!-- input mux: ($(arg joy_topic) & $(arg joy_topic_dummy)) -> / -->
+  <node name="input_joy_mux"
+        pkg="topic_tools" type="mux"
+        respawn="true"
+	      args="$(arg joy_topic_to_input) $(arg joy_topic_dummy) $(arg joy_topic)">
+    <remap from="mux" to="input_joy_mux" />
+  </node>
+
+  <node name="input_joy_selector"
+        pkg="jsk_robot_startup" type="mux_selector.py"
+	      respawn="true"
+	      args="$(arg joy_topic) 'm.buttons[5]==1' $(arg joy_topic) $(arg joy_topic) 'm.buttons[4]==1' $(arg joy_topic_dummy)">
+    <remap from="mux" to="input_joy_mux" />
+    <param name="wait" value="true" />
+  </node>
+
 </launch>

--- a/jsk_unitree_robot/jsk_unitree_startup/launch/unitree_bringup.launch
+++ b/jsk_unitree_robot/jsk_unitree_startup/launch/unitree_bringup.launch
@@ -33,6 +33,12 @@
 
   <include file="$(find app_manager)/launch/app_manager.launch" />
 
+  <!-- start lead teleop.launch -->
+  <node name="rosservice"
+        pkg="rosservice" type="rosservice"
+        args="call --wait /robot/start_app 'name: jsk_unitree_startup/lead_teleop'"
+        output="screen" />
+
   <!-- let people to know unitree is bringup -->
   <node pkg="jsk_unitree_startup" type="wakeup.l"
         name="wakeup" output="log" />


### PR DESCRIPTION
# What is this?

To switch lead teleop mode and without lead teleop mode, I added mux function.
https://github.com/k-okada/jsk_robot/pull/51
Considering this discussion, I used app_manager's lead_teleop by calling rosservice call.

https://user-images.githubusercontent.com/4690682/175353117-826b88ac-343b-432f-8d20-4699ca33e867.mp4


