### PR TITLE
[jsk_unitree_startup/jsk_startup.sh] Drop rosserial_node.launch on nano2

### DIFF
--- a/jsk_unitree_robot/jsk_unitree_startup/autostart/jsk_startup.sh
+++ b/jsk_unitree_robot/jsk_unitree_startup/autostart/jsk_startup.sh
@@ -26,10 +26,6 @@ if [ "$ROS_IP" == "192.168.123.14" ];then
        # At this moment, nano1 have only 2G memory and fail to start live_human_pose.py....
        DISPLAY=:0.0 gnome-terminal -- bash -c "export GST_PLUGIN_PATH=/home/unitree/Unitree/autostart/imageai/mLComSystemFrame/ThirdParty/webSinkPipe/build; cd /home/unitree/Unitree/autostart/imageai/mLComSystemFrame/pyScripts; PYTHONPATH= python3 live_human_pose.py; exec bash"
     fi
-    # Go1 Pro runs rosserial_node on nano2
-    if [ "$ROS_IP" == "192.168.123.14" ];then
-        roslaunch --screen jsk_unitree_startup rosserial_node.launch &
-    fi
     # wait for soundplay
     while ! eval rostopic info /robotsound 2$toStartlog; do sleep 2; done
     sleep 2 # wait for a while...


### PR DESCRIPTION
# What is this?

In current, `rosserial_node.launch` is launched on `rasberrypi` and `nano2`.
Since the same node is started up, the names collide and the serial node does not start up correctly.

@k-okada How about launch a `rosserial_node.launch` with raspberry pi for both air and pro?

cc: @tkmtnt7000
