### PR TITLE
[jsk_pepper_startup/package.xml] add run depend of roseus_smach

### DIFF
--- a/jsk_naoqi_robot/jsk_pepper_startup/package.xml
+++ b/jsk_naoqi_robot/jsk_pepper_startup/package.xml
@@ -22,6 +22,7 @@
   <run_depend>nao_interaction_msgs</run_depend>
   <run_depend>pepper_bringup</run_depend>
   <run_depend>roseus</run_depend>
+  <run_depend>roseus_smach</run_depend>
   <run_depend>rostwitter</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>


### PR DESCRIPTION
If we use apps in `jsk_pepper_startup`, it will require `roseus_smach` package.