### PR TITLE
[jsk_robot_startup/smach_to_mail] Not use yaml file to set address

### DIFF
--- a/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
+++ b/jsk_robot_common/jsk_robot_startup/scripts/smach_to_mail.py
@@ -3,11 +3,9 @@
 import base64
 import cv2
 import datetime
-import os
 import pickle
 import rospy
 import sys
-import yaml
 
 from cv_bridge import CvBridge
 from jsk_robot_startup.msg import Email
@@ -30,27 +28,16 @@ class SmachToMail():
         self.bridge = CvBridge()
         self.smach_state_list = {}  # for status list
         self.smach_state_subject = {}  # for status subject
-        yaml_path = rospy.get_param(
-            '~email_info', "/var/lib/robot/email_info.yaml")
-        if os.path.exists(yaml_path):
-            with open(yaml_path) as yaml_f:
-                self.email_info = yaml.load(yaml_f)
-            rospy.loginfo(
-                "{} is loaded as email config file.".format(yaml_path))
-            rospy.loginfo(self.email_info)
-            self.sender_address = self.email_info['sender_address']
-            self.receiver_address = self.email_info['receiver_address']
+        if rospy.has_param("~sender_address"):
+            self.sender_address = rospy.get_param("~sender_address")
         else:
-            if rospy.has_param("~sender_address"):
-                self.sender_address = rospy.get_param("~sender_address")
-            else:
-                rospy.logerr("Please set rosparam {}/sender_address".format(
+            rospy.logerr("Please set rosparam {}/sender_address".format(
+                rospy.get_name()))
+        if rospy.has_param("~receiver_address"):
+            self.receiver_address = rospy.get_param("~receiver_address")
+        else:
+            rospy.logerr("Please set rosparam {}/receiver_address".format(
                     rospy.get_name()))
-            if rospy.has_param("~receiver_address"):
-                self.receiver_address = rospy.get_param("~receiver_address")
-            else:
-                rospy.logerr("Please set rosparam {}/receiver_address".format(
-                        rospy.get_name()))
 
 
     def _status_cb(self, msg):


### PR DESCRIPTION
This reverts commit b73a8ac0fe1cefd3533256feca893f6496fd46a9.
We do not use yaml file (`/var/lib/robot/...yaml`) to set sender and receiver address.
From https://github.com/k-okada/jsk_robot/pull/71#issuecomment-1223458987
