### PR TITLE
fix supervisor and app chooser URLs

### DIFF
--- a/jsk_spot_robot/README.md
+++ b/jsk_spot_robot/README.md
@@ -41,11 +41,11 @@ Basically, ros systemd services will start automatically. So you can use spot no
 
 #### superviosur
 
-URI: https://<robot_ip>:9001
+URI: http://<robot_ip>:9001
 
 #### rwt_app_chooser
 
-URI: https://<robot_ip>:8000/rwt_app_chooser
+URI: http://<robot_ip>:8000/rwt_app_chooser
 
 ### Development with a remote PC
 


### PR DESCRIPTION
Fix urls of supervisor and app chooser because I cannot reach these pages with https.

`https://<robot_ip>:9001` and `https://<robot_ip>:8000/rwt_app_chooser`
to
`http://<robot_ip>:9001` and `http://<robot_ip>:8000/rwt_app_chooser`