### PR TITLE
add allow-other-keys for args

### DIFF
--- a/jsk_spot_robot/spoteus/spot-interface.l
+++ b/jsk_spot_robot/spoteus/spot-interface.l
@@ -47,7 +47,7 @@
 
 (defmethod spot-interface
   (:init
-   (&rest args &key (trajectory-cmd-action-name "/spot/trajectory"))
+   (&rest args &key (trajectory-cmd-action-name "/spot/trajectory") &allow-other-keys)
    (prog1
        (send-super* :init :robot spot-robot :base-frame-id "base_link" :odom-topic "/odom_combined" :base-controller-action-name nil args)
      ;; check if spot_ros/driver.launch started


### PR DESCRIPTION
add `allow-other-keys` to avoid key not found error.