### PR TITLE
[jsk_spot_startup] add roslint depend

### DIFF
--- a/jsk_spot_robot/jsk_spot_startup/package.xml
+++ b/jsk_spot_robot/jsk_spot_startup/package.xml
@@ -47,6 +47,7 @@
   <exec_depend>xacro</exec_depend>
   <exec_depend>xterm</exec_depend>
 
+  <test_depend>roslint</test_depend>
   <test_depend>rostest</test_depend>
 
   <export>


### PR DESCRIPTION
roslint is used at [here](https://github.com/k-okada/jsk_robot/blob/f0294d30203ec49b5292427e909e16375e804992/jsk_spot_robot/jsk_spot_startup/CMakeLists.txt#L35).  