### PR TITLE
[spot] publish compressed hand_depth_in_hand_color_frame topic

### DIFF
--- a/jsk_spot_robot/jsk_spot_startup/launch/include/driver.launch
+++ b/jsk_spot_robot/jsk_spot_startup/launch/include/driver.launch
@@ -101,6 +101,8 @@
 	args="raw in:=/spot/camera/hand_color/image compressed out:=/spot/camera/hand_color/image" />
   <node pkg="image_transport" type="republish" name="hand_depth_compress"
 	args="raw in:=/spot/camera/hand_depth/image compressedDepth out:=/spot/camera/hand_depth/image" />
+  <node pkg="image_transport" type="republish" name="hand_depth_in_color_frame_compress"
+        args="raw in:=/spot/camera/hand_depth_in_hand_color_frame/image compressedDepth out:=/spot/camera/hand_depth_in_hand_color_frame/image" />
 
   <node pkg="image_transport" type="republish" name="frontleft_compress"
 	args="raw in:=/spot/camera/frontleft/image compressed out:=/spot/camera/frontleft/image" />


### PR DESCRIPTION
I use `/spot/camera/hand_depth_in_hand_color_frame/image` to manipulate objects. I want to publish a compressed version of it.