### PR TITLE
[jsk_spot_robot] remove unnecessary repos

### DIFF
--- a/jsk_spot_robot/jsk_spot_user.rosinstall
+++ b/jsk_spot_robot/jsk_spot_user.rosinstall
@@ -4,13 +4,3 @@
     local-name: spot-ros
     uri: https://github.com/k-okada/spot_ros-arm.git
     version: arm
-## to support custom limb name, we need https://github.com/jsk-ros-pkg/jsk_model_tools/pull/249
-- git:
-    local-name: jsk_model_tools
-    uri: https://github.com/k-okada/jsk_model_tools.git
-    version: custom_limb
-# wait for https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/443 (add volume key arg for robot-interface :speak) to be released
-- git:
-    local-name: jsk_pr2eus
-    uri:     https://github.com/jsk-ros-pkg/jsk_pr2eus.git
-    version: master


### PR DESCRIPTION
(rewrited version of https://github.com/k-okada/jsk_robot/pull/114) 

Some repos in jsk_spot_user.rosinstall have been released. This PR removes them.